### PR TITLE
[FEAT] Trend Page 모바일 뷰 구현

### DIFF
--- a/nova-app/src/app/(protected)/trend/page.tsx
+++ b/nova-app/src/app/(protected)/trend/page.tsx
@@ -1,20 +1,21 @@
+'use client';
 import { CategoriesKeyword, KeywordTop, TrendChart, BarChart } from '@/features/trend/ui';
 import { Header, PageHeader, SelectionChip } from '@/shared/ui';
 import { ChartBar } from 'lucide-react';
 
 const TrendPage = () => {
   return (
-    <div className='md:px-5 p-4 overflow-x-auto'>
+    <div className='md:px-5 p-4 '>
       <PageHeader text='트렌드' icon={ChartBar} className='p-0 mb-4 md:-mx-1' />
       {/* 트렌드차트 */}
-      <section className='rounded-static-frame bg-base p-5 mb-4'>
+      <section className='rounded-static-frame bg-base p-5 flex flex-col gap-4 mb-4 md:gap-5'>
         <SelectionChip
           isShowChevron={false}
           label='최근 7일'
           size={'md'}
           style={'surface'}
           selected={true}
-          className='mb-5'
+          className='w-fit'
         />
         <Header
           size='md'
@@ -25,15 +26,12 @@ const TrendPage = () => {
       </section>
 
       {/* 인기키워드 */}
-      <KeywordTop />
+      <section className='rounded-2xl bg-static p-5 flex flex-col gap-4 mb-4 md:gap-5'>
+        <KeywordTop />
+      </section>
 
       <section className='rounded-static-frame bg-base p-5 mb-4'>
-        <Header
-          size='md'
-          label='카테고리 내 키워드 언급량'
-          description='전체 언급 수 기준'
-          className='mb-3'
-        />
+        <Header size='md' label='카테고리 내 키워드 언급량' description='전체 언급 수 기준' />
         <BarChart />
       </section>
       {/* 카테고리 키워드 */}

--- a/nova-app/src/app/(protected)/trend/page.tsx
+++ b/nova-app/src/app/(protected)/trend/page.tsx
@@ -39,6 +39,7 @@ const TrendPage = () => {
           size='md'
           label={` ${selected} 카테고리 내 키워드 언급량`}
           description='전체 언급 수 기준'
+          className='break-keep'
         />
         <BarChart />
       </section>

--- a/nova-app/src/app/(protected)/trend/page.tsx
+++ b/nova-app/src/app/(protected)/trend/page.tsx
@@ -1,4 +1,3 @@
-'use client';
 import { CategoriesKeyword, KeywordTop, TrendChart, BarChart } from '@/features/trend/ui';
 import { Header, PageHeader, SelectionChip } from '@/shared/ui';
 import { ChartBar } from 'lucide-react';
@@ -26,7 +25,7 @@ const TrendPage = () => {
       </section>
 
       {/* 인기키워드 */}
-      <section className='rounded-2xl bg-static p-5 flex flex-col gap-4 mb-4 md:gap-5'>
+      <section className='rounded-static-frame bg-base p-5 flex flex-col gap-4 mb-4 md:gap-5'>
         <KeywordTop />
       </section>
 

--- a/nova-app/src/app/(protected)/trend/page.tsx
+++ b/nova-app/src/app/(protected)/trend/page.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import { CategoriesKeyword, KeywordTop, TrendChart, BarChart } from '@/features/trend/ui';
 import { Header, PageHeader, SelectionChip } from '@/shared/ui';
 import { ChartBar } from 'lucide-react';
+import { useState } from 'react';
 
 const TrendPage = () => {
+  const [selected, setSelected] = useState<string>('');
+
   return (
     <div className='md:px-5 p-4 '>
       <PageHeader text='트렌드' icon={ChartBar} className='p-0 mb-4 md:-mx-1' />
@@ -30,11 +35,15 @@ const TrendPage = () => {
       </section>
 
       <section className='rounded-static-frame bg-base p-5 mb-4'>
-        <Header size='md' label='카테고리 내 키워드 언급량' description='전체 언급 수 기준' />
+        <Header
+          size='md'
+          label={` ${selected} 카테고리 내 키워드 언급량`}
+          description='전체 언급 수 기준'
+        />
         <BarChart />
       </section>
       {/* 카테고리 키워드 */}
-      <CategoriesKeyword />
+      <CategoriesKeyword selected={selected} onSelected={setSelected} />
     </div>
   );
 };

--- a/nova-app/src/features/trend/ui/CategoriesKeyword.tsx
+++ b/nova-app/src/features/trend/ui/CategoriesKeyword.tsx
@@ -1,14 +1,16 @@
 'use client';
 import { keyword_data } from '@/features/trend/mock/keyword';
 import { cn } from '@/shared/utils/cn';
-import { useState } from 'react';
 
-export const CategoriesKeyword = () => {
-  const [selected, setSelected] = useState<string | null>('');
-
+interface CategoriesKeywordProp {
+  selected: string;
+  onSelected: (value: string) => void;
+}
+export const CategoriesKeyword = ({ selected, onSelected }: CategoriesKeywordProp) => {
   const handleClick = (title: string) => {
-    setSelected((pre) => (pre === title ? null : title));
+    onSelected(selected === title ? '' : title);
   };
+  console.log(selected);
 
   return (
     <section className='grid grid-cols-2 md:gap-4 gap-2.5'>
@@ -25,7 +27,7 @@ export const CategoriesKeyword = () => {
           >
             <h6
               className={cn(
-                'md:text-left! text-center text-optional typo-headline-strong',
+                'md:text-left! text-center text-optional typo-body-strong',
                 isSelected && 'text-peak',
               )}
             >

--- a/nova-app/src/features/trend/ui/CategoriesKeyword.tsx
+++ b/nova-app/src/features/trend/ui/CategoriesKeyword.tsx
@@ -11,24 +11,29 @@ export const CategoriesKeyword = () => {
   };
 
   return (
-    <section className='grid grid-cols-2 gap-4 '>
+    <section className='grid grid-cols-2 md:gap-4 gap-2.5'>
       {keyword_data.map((item) => {
         const isSelected = selected === item.title;
         return (
           <div
             className={cn(
-              'rounded-2xl bg-static p-5 pb-4 cursor-pointer',
+              'rounded-static-frame bg-static md:p-5 px-5 py-2.5 cursor-pointer',
               isSelected && 'bg-accent-peak shadow-[0_4px_4px_0_rgba(0,0,0,0.25)]',
             )}
             key={item.title}
             onClick={() => handleClick(item.title)}
           >
-            <h6 className={cn(' text-optional typo-headline-strong', isSelected && 'text-peak')}>
+            <h6
+              className={cn(
+                'md:text-left! text-center text-optional typo-headline-strong',
+                isSelected && 'text-peak',
+              )}
+            >
               {item.title}
             </h6>
             <p
               className={cn(
-                'typo-subhead-base text-inactive line-clamp-1 text-ellipsis overflow-hidden',
+                'hidden md:block! typo-subhead-base text-inactive  truncate',
                 isSelected && 'text-peak',
               )}
             >

--- a/nova-app/src/features/trend/ui/KeywordTop.tsx
+++ b/nova-app/src/features/trend/ui/KeywordTop.tsx
@@ -5,7 +5,8 @@ import { Button, Header, TextBadge } from '@/shared/ui';
 import { cn } from '@/shared/utils/cn';
 
 export const KeywordTop = () => {
-  const gridCols = 'grid grid-cols-[0.95fr_2.86fr_2.86fr_1.43fr_1.35fr_0.55fr] gap-x-[20px]';
+  const gridCols =
+    'md:grid md:grid-cols-[0.95fr_2.86fr_2.86fr_1.43fr_1.35fr_0.55fr] md:gap-x-[20px]';
 
   const { keywords, toggleKeyword } = useCompanyStore();
   return (
@@ -18,14 +19,18 @@ export const KeywordTop = () => {
 
       <div className='border-outline rounded-interactive-default border '>
         <div
-          className={`${gridCols} px-8 py-3 bg-peak text-white  typo-body-strong  rounded-t-interactive-default items-center `}
+          className={cn(
+            'flex justify-between items-center p-3 bg-peak text-white typo-body-strong rounded-t-interactive-default',
+            gridCols,
+            'md:px-8 md:py-3',
+          )}
         >
-          <div className='text-center'>순위</div>
-          <div className='text-left '>키워드</div>
-          <div className='text-center'>카테고리</div>
-          <div className=' text-center'>언급수</div>
-          <div className='text-left'>변화율</div>
-          <div className='text-center'>선택</div>
+          <div className='w-10 md:w-auto text-center'>순위</div>
+          <div className='flex-1 w-30 md:flex-none md:w-auto text-left '>키워드</div>
+          <div className='hidden md:block  text-center md:w-auto'>카테고리</div>
+          <div className='hidden md:block text-center md:w-auto'>언급수</div>
+          <div className='w-12.5 md:w-auto text-center  md:text-left mr-3 md:mr-0'>변화율</div>
+          <div className='w-10 text-center'>선택</div>
         </div>
         <div className='divide-y divide-outline'>
           {KEYWORDS.map((item) => {
@@ -34,20 +39,24 @@ export const KeywordTop = () => {
               <div
                 key={item.rank}
                 className={cn(
-                  `${gridCols} px-8 py-3 typo-callout-base  text-optional border-b border-outline items-center`,
-                  isSelected && 'bg-surface  text-base-color border-black',
+                  'flex justify-between  items-center border-b border-outline p-3 md:px-8 md:py-3',
+                  gridCols,
+                  'typo-callout-base text-optional',
+                  isSelected && 'bg-surface text-base-color border-black',
                 )}
               >
-                <p className=' text-center'>{item.rank}</p>
-                <p className='text-left'>{item.keyword}</p>
-                <p className=' text-center '>{item.category}</p>
-                <p className='text-center'>{item.count.toLocaleString()}</p>
+                <p className=' text-center w-10 md:w-auto'>{item.rank}</p>
+                <p className='flex-1 md:flex-none  md:w-auto  text-left  '>{item.keyword}</p>
+                <p className='hidden md:block md:w-auto text-center '>{item.category}</p>
+                <p className='hidden md:block md:w-auto text-center '>
+                  {item.count.toLocaleString()}
+                </p>
                 <TextBadge
                   text={`${item.changeRate}%`}
                   size='md'
                   variant={item.changeRate.slice(0, 1) === '+' ? 'data' : 'accent'}
                   peak={false}
-                  className='w-fit items-left'
+                  className='w-fit mr-3 md:mr-0'
                 />
                 <Button
                   label={isSelected ? '취소' : '선택'}
@@ -55,6 +64,7 @@ export const KeywordTop = () => {
                   peak={isSelected}
                   size='sm'
                   onClick={() => toggleKeyword(item.keyword)}
+                  className='w-fit'
                 />
               </div>
             );
@@ -62,6 +72,5 @@ export const KeywordTop = () => {
         </div>
       </div>
     </>
-    // </section>
   );
 };

--- a/nova-app/src/features/trend/ui/KeywordTop.tsx
+++ b/nova-app/src/features/trend/ui/KeywordTop.tsx
@@ -56,7 +56,7 @@ export const KeywordTop = () => {
                   size='md'
                   variant={item.changeRate.slice(0, 1) === '+' ? 'data' : 'accent'}
                   peak={false}
-                  className='md:w-fit items-left w-12.5 mr-3 md:mr-0'
+                  className='w-fit mr-3 md:mr-0'
                 />
                 <Button
                   label={isSelected ? '취소' : '선택'}

--- a/nova-app/src/features/trend/ui/KeywordTop.tsx
+++ b/nova-app/src/features/trend/ui/KeywordTop.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/shared/utils/cn';
 
 export const KeywordTop = () => {
   const gridCols =
-    'md:grid md:grid-cols-[0.95fr_2.86fr_2.86fr_1.43fr_1.35fr_0.55fr] md:gap-x-[20px]';
+    'lg:grid lg:grid-cols-[0.95fr_2.86fr_2.86fr_1.43fr_1.35fr_0.55fr] lg:gap-x-[20px]';
 
   const { keywords, toggleKeyword } = useCompanyStore();
   return (
@@ -22,14 +22,14 @@ export const KeywordTop = () => {
           className={cn(
             'flex justify-between items-center p-3 bg-peak text-white typo-body-strong rounded-t-interactive-default',
             gridCols,
-            'md:px-8 md:py-3',
+            'lg:px-8 lg:py-3',
           )}
         >
-          <div className='w-10 md:w-auto text-center'>순위</div>
-          <div className='flex-1 w-30 md:flex-none md:w-auto text-left '>키워드</div>
-          <div className='hidden md:block  text-center md:w-auto'>카테고리</div>
-          <div className='hidden md:block text-center md:w-auto'>언급수</div>
-          <div className='w-12.5 md:w-auto text-center  md:text-left mr-3 md:mr-0'>변화율</div>
+          <div className='w-10 lg:w-auto text-center'>순위</div>
+          <div className='flex-1 w-30 ;g:flex-none lg:w-auto text-left '>키워드</div>
+          <div className='hidden lg:block  text-center lg:w-auto'>카테고리</div>
+          <div className='hidden lg:block text-center lg:w-auto'>언급수</div>
+          <div className='w-12.5 lg:w-auto text-center  lg:text-left mr-3 lg:mr-0'>변화율</div>
           <div className='w-10 text-center'>선택</div>
         </div>
         {KEYWORDS.map((item) => {
@@ -38,7 +38,7 @@ export const KeywordTop = () => {
             <div
               key={item.rank}
               className={cn(
-                'flex  items-center p-3 md:px-8 md:py-3 relative',
+                'flex  items-center p-3 lg:px-8 lg:py-3 relative',
                 gridCols,
                 'typo-callout-base text-optional',
                 'border-b border-outline ',
@@ -48,10 +48,10 @@ export const KeywordTop = () => {
                 ],
               )}
             >
-              <p className=' text-center w-10 md:w-auto'>{item.rank}</p>
-              <p className='flex-1 md:flex-none  md:w-auto  text-left  '>{item.keyword}</p>
-              <p className='hidden md:block md:w-auto text-center '>{item.category}</p>
-              <p className='hidden md:block md:w-auto text-center '>
+              <p className=' text-center w-10 lg:w-auto'>{item.rank}</p>
+              <p className='flex-1 lg:flex-none  lg:w-auto  text-left  '>{item.keyword}</p>
+              <p className='hidden lg:block lg:w-auto text-center '>{item.category}</p>
+              <p className='hidden lg:block lg:w-auto text-center '>
                 {item.count.toLocaleString()}
               </p>
               <TextBadge
@@ -59,7 +59,7 @@ export const KeywordTop = () => {
                 size='md'
                 variant={item.changeRate.slice(0, 1) === '+' ? 'data' : 'accent'}
                 peak={false}
-                className='w-fit mr-3 md:mr-0'
+                className='w-fit mr-3 lg:mr-0'
               />
               <Button
                 label={isSelected ? '취소' : '선택'}

--- a/nova-app/src/features/trend/ui/KeywordTop.tsx
+++ b/nova-app/src/features/trend/ui/KeywordTop.tsx
@@ -9,12 +9,11 @@ export const KeywordTop = () => {
 
   const { keywords, toggleKeyword } = useCompanyStore();
   return (
-    <section className='rounded-2xl bg-static p-5 mb-4'>
+    <>
       <Header
         size='md'
         label='인기 키워드 TOP 10'
         description='아래의 표를 클릭하여 비교할 키워드를 추가하세요'
-        className='mb-5'
       />
 
       <div className='border-outline rounded-interactive-default border '>
@@ -22,9 +21,9 @@ export const KeywordTop = () => {
           className={`${gridCols} px-8 py-3 bg-peak text-white  typo-body-strong  rounded-t-interactive-default items-center `}
         >
           <div className='text-center'>순위</div>
-          <div className='text-left'>키워드</div>
+          <div className='text-left '>키워드</div>
           <div className='text-center'>카테고리</div>
-          <div className='text-center'>언급수</div>
+          <div className=' text-center'>언급수</div>
           <div className='text-left'>변화율</div>
           <div className='text-center'>선택</div>
         </div>
@@ -41,7 +40,7 @@ export const KeywordTop = () => {
               >
                 <p className=' text-center'>{item.rank}</p>
                 <p className='text-left'>{item.keyword}</p>
-                <p className=' text-center'>{item.category}</p>
+                <p className=' text-center '>{item.category}</p>
                 <p className='text-center'>{item.count.toLocaleString()}</p>
                 <TextBadge
                   text={`${item.changeRate}%`}
@@ -62,6 +61,7 @@ export const KeywordTop = () => {
           })}
         </div>
       </div>
-    </section>
+    </>
+    // </section>
   );
 };

--- a/nova-app/src/features/trend/ui/KeywordTop.tsx
+++ b/nova-app/src/features/trend/ui/KeywordTop.tsx
@@ -5,7 +5,8 @@ import { Button, Header, TextBadge } from '@/shared/ui';
 import { cn } from '@/shared/utils/cn';
 
 export const KeywordTop = () => {
-  const gridCols = 'grid grid-cols-[0.95fr_2.86fr_2.86fr_1.43fr_1.35fr_0.55fr] gap-x-[20px]';
+  const gridCols =
+    'md:grid md:grid-cols-[0.95fr_2.86fr_2.86fr_1.43fr_1.35fr_0.55fr] md:gap-x-[20px]';
 
   const { keywords, toggleKeyword } = useCompanyStore();
   return (
@@ -18,14 +19,18 @@ export const KeywordTop = () => {
 
       <div className='border-outline rounded-interactive-default border '>
         <div
-          className={`${gridCols} px-8 py-3 bg-peak text-white  typo-body-strong  rounded-t-interactive-default items-center `}
+          className={cn(
+            'flex justify-between items-center p-3 bg-peak text-white typo-body-strong rounded-t-interactive-default',
+            gridCols,
+            'md:px-8 md:py-3',
+          )}
         >
-          <div className='text-center'>순위</div>
-          <div className='text-left '>키워드</div>
-          <div className='text-center'>카테고리</div>
-          <div className=' text-center'>언급수</div>
-          <div className='text-left'>변화율</div>
-          <div className='text-center'>선택</div>
+          <div className='w-10 md:w-auto text-center'>순위</div>
+          <div className='flex-1 w-30 md:flex-none md:w-auto text-left '>키워드</div>
+          <div className='hidden md:block  text-center md:w-auto'>카테고리</div>
+          <div className='hidden md:block text-center md:w-auto'>언급수</div>
+          <div className='w-12.5 md:w-auto text-center  md:text-left mr-3 md:mr-0'>변화율</div>
+          <div className='w-10 text-center'>선택</div>
         </div>
         <div className='divide-y divide-outline'>
           {KEYWORDS.map((item) => {
@@ -34,20 +39,24 @@ export const KeywordTop = () => {
               <div
                 key={item.rank}
                 className={cn(
-                  `${gridCols} px-8 py-3 typo-callout-base  text-optional border-b border-outline items-center`,
-                  isSelected && 'bg-surface  text-base-color border-black',
+                  'flex justify-between  items-center border-b border-outline p-3 md:px-8 md:py-3',
+                  gridCols,
+                  'typo-callout-base text-optional',
+                  isSelected && 'bg-surface text-base-color border-black',
                 )}
               >
-                <p className=' text-center'>{item.rank}</p>
-                <p className='text-left'>{item.keyword}</p>
-                <p className=' text-center '>{item.category}</p>
-                <p className='text-center'>{item.count.toLocaleString()}</p>
+                <p className=' text-center w-10 md:w-auto'>{item.rank}</p>
+                <p className='flex-1 md:flex-none  md:w-auto  text-left  '>{item.keyword}</p>
+                <p className='hidden md:block md:w-auto text-center '>{item.category}</p>
+                <p className='hidden md:block md:w-auto text-center '>
+                  {item.count.toLocaleString()}
+                </p>
                 <TextBadge
                   text={`${item.changeRate}%`}
                   size='md'
                   variant={item.changeRate.slice(0, 1) === '+' ? 'data' : 'accent'}
                   peak={false}
-                  className='w-fit items-left'
+                  className='md:w-fit items-left w-12.5 mr-3 md:mr-0'
                 />
                 <Button
                   label={isSelected ? '취소' : '선택'}
@@ -55,6 +64,7 @@ export const KeywordTop = () => {
                   peak={isSelected}
                   size='sm'
                   onClick={() => toggleKeyword(item.keyword)}
+                  className='w-fit'
                 />
               </div>
             );
@@ -62,6 +72,5 @@ export const KeywordTop = () => {
         </div>
       </div>
     </>
-    // </section>
   );
 };

--- a/nova-app/src/features/trend/ui/KeywordTop.tsx
+++ b/nova-app/src/features/trend/ui/KeywordTop.tsx
@@ -32,44 +32,46 @@ export const KeywordTop = () => {
           <div className='w-12.5 md:w-auto text-center  md:text-left mr-3 md:mr-0'>변화율</div>
           <div className='w-10 text-center'>선택</div>
         </div>
-        <div className='divide-y divide-outline'>
-          {KEYWORDS.map((item) => {
-            const isSelected = keywords.includes(item.keyword);
-            return (
-              <div
-                key={item.rank}
-                className={cn(
-                  'flex justify-between  items-center border-b border-outline p-3 md:px-8 md:py-3',
-                  gridCols,
-                  'typo-callout-base text-optional',
-                  isSelected && 'bg-surface text-base-color border-black',
-                )}
-              >
-                <p className=' text-center w-10 md:w-auto'>{item.rank}</p>
-                <p className='flex-1 md:flex-none  md:w-auto  text-left  '>{item.keyword}</p>
-                <p className='hidden md:block md:w-auto text-center '>{item.category}</p>
-                <p className='hidden md:block md:w-auto text-center '>
-                  {item.count.toLocaleString()}
-                </p>
-                <TextBadge
-                  text={`${item.changeRate}%`}
-                  size='md'
-                  variant={item.changeRate.slice(0, 1) === '+' ? 'data' : 'accent'}
-                  peak={false}
-                  className='w-fit mr-3 md:mr-0'
-                />
-                <Button
-                  label={isSelected ? '취소' : '선택'}
-                  style='surface'
-                  peak={isSelected}
-                  size='sm'
-                  onClick={() => toggleKeyword(item.keyword)}
-                  className='w-fit'
-                />
-              </div>
-            );
-          })}
-        </div>
+        {KEYWORDS.map((item) => {
+          const isSelected = keywords.includes(item.keyword);
+          return (
+            <div
+              key={item.rank}
+              className={cn(
+                'flex  items-center p-3 md:px-8 md:py-3 relative',
+                gridCols,
+                'typo-callout-base text-optional',
+                'border-b border-outline ',
+                isSelected && [
+                  'z-10 bg-surface text-base-color border-black',
+                  'before:absolute before:-top-px before:left-0 before:w-full before:h-px before:bg-black ',
+                ],
+              )}
+            >
+              <p className=' text-center w-10 md:w-auto'>{item.rank}</p>
+              <p className='flex-1 md:flex-none  md:w-auto  text-left  '>{item.keyword}</p>
+              <p className='hidden md:block md:w-auto text-center '>{item.category}</p>
+              <p className='hidden md:block md:w-auto text-center '>
+                {item.count.toLocaleString()}
+              </p>
+              <TextBadge
+                text={`${item.changeRate}%`}
+                size='md'
+                variant={item.changeRate.slice(0, 1) === '+' ? 'data' : 'accent'}
+                peak={false}
+                className='w-fit mr-3 md:mr-0'
+              />
+              <Button
+                label={isSelected ? '취소' : '선택'}
+                style='surface'
+                peak={isSelected}
+                size='sm'
+                onClick={() => toggleKeyword(item.keyword)}
+                className='w-fit'
+              />
+            </div>
+          );
+        })}
       </div>
     </>
   );

--- a/nova-app/src/features/trend/ui/TrendChart.tsx
+++ b/nova-app/src/features/trend/ui/TrendChart.tsx
@@ -10,8 +10,10 @@ export const TrendChart = () => {
   return (
     <div className='bg-static rounded-2xl'>
       {/* 차트 */}
-      <div className='h-77.5 px-2'>
-        <Line data={trendChartData} options={createTrendOptions()} />
+      <div className='overflow-x-auto'>
+        <div className='min-w-[640px] h-77.5'>
+          <Line data={trendChartData} options={createTrendOptions()} />
+        </div>
       </div>
 
       {/* legend */}


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ‼️ 관련 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

- resolves #54 

## 👩🏻‍💻 작업 사항

<!-- 주요 작업 내용을 간단히 작성해주세요.(스크린샷도 있으면 좋아요!) -->
- 모바일뷰 레이아웃을 구현했습니다.  기준값: md

## 📢 기타(공유 사항)
인기 키워드 쪽은 table을 grid에서 flex로 변경하다보니 코드가 약간 더러운데 화면은 똑같이 나와여

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive category selection on the Trend page with dynamic header labels reflecting the chosen category.
  * Selection-propagation across keyword lists and top keyword area; visual highlight for selected rows.
  * Horizontally scrollable chart area for improved readability on narrow viewports.

* **Style**
  * Enhanced responsive layouts, spacing, and card/list presentation for clearer hierarchy across screen sizes.
  * Compact, adaptive headers and column behavior for better mobile display.

* **Bug Fixes**
  * Keyword cards now display actual content text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->